### PR TITLE
Fixes #164 (search bar autocorrect issue)

### DIFF
--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -19,6 +19,7 @@ class CustomInputField extends StatelessWidget {
   final bool expands;
   final int baseOffset;
   final EdgeInsets? padding;
+  final TextInputType? textInputType;
 
   var textController = TextEditingController();
 
@@ -45,6 +46,7 @@ class CustomInputField extends StatelessWidget {
     this.expands = false,
     this.baseOffset = 0,
     this.padding,
+    this.textInputType,
   });
 
   @override
@@ -79,8 +81,9 @@ class CustomInputField extends StatelessWidget {
               child: TextField(
                 autocorrect: false, // textfield autocorrect off
                 enableSuggestions: false,
-                keyboardType: TextInputType
-                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
+                keyboardType: textInputType ??
+                    TextInputType
+                        .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),
@@ -106,7 +109,7 @@ class CustomInputField extends StatelessWidget {
                 maxLines: expands ? null : maxLines,
                 expands: expands,
                 onChanged: (val) {
-                  if (value != null) value!(val);
+                  if (value != null) value!(val.replaceAll(' ', ''));
                 },
                 controller: textController,
                 onSubmitted: (str) {

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -77,6 +77,10 @@ class CustomInputField extends StatelessWidget {
           children: <Widget>[
             Expanded(
               child: TextField(
+                autocorrect: false, // textfield autocorrect off
+                enableSuggestions: false,
+                keyboardType: TextInputType
+                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: at_follows_flutter
       ref: "fix/at_follows_flutter_example"
       resolved-ref: "4831bb7841df57486fd84c3228746510b95dc718"
-      url: "git@github.com:atsign-foundation/at_widgets.git"
+      url: "https://github.com/atsign-foundation/at_widgets.git"
     source: git
     version: "3.0.5"
   at_location_flutter:


### PR DESCRIPTION
- What I did
I disabled the search bar autocorrect to solve the issue.

- How I did it
To disable autocorrect, Flutter's TextField Widget provides autocorrect option which I toggled to false, along with the enableSuggestions option. Also, this doesn't work if the device's keyboard's autocorrect is on. So I set the keyboardType as visiblePassword (TextInputType.visiblePassword). It prevents the autocorrect in both the cases. 

- How to verify it
Type any user's atsign (for example barbaras). It previously autocorrected to Barbara's. Now it just displays barbaras, i.e. whatever we type.

- Description for the changelog
Toggled Searchbar TextField autocorrect to false and set TextInputType to visiblePassword, for disabling autocorrect on the search bar.
