### PR TITLE
Fixes #164 (search bar autocorrect and blank spaces issue)

### DIFF
--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -19,6 +19,7 @@ class CustomInputField extends StatelessWidget {
   final bool expands;
   final int baseOffset;
   final EdgeInsets? padding;
+  final TextInputType? textInputType;
 
   var textController = TextEditingController();
 
@@ -45,6 +46,7 @@ class CustomInputField extends StatelessWidget {
     this.expands = false,
     this.baseOffset = 0,
     this.padding,
+    this.textInputType,
   });
 
   @override
@@ -79,8 +81,9 @@ class CustomInputField extends StatelessWidget {
               child: TextField(
                 autocorrect: false, // textfield autocorrect off
                 enableSuggestions: false,
-                keyboardType: TextInputType
-                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
+                keyboardType: textInputType ??
+                    TextInputType
+                        .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),
@@ -106,7 +109,7 @@ class CustomInputField extends StatelessWidget {
                 maxLines: expands ? null : maxLines,
                 expands: expands,
                 onChanged: (val) {
-                  if (value != null) value!(val);
+                  if (value != null) value!(val.replaceAll(' ', ''));
                 },
                 controller: textController,
                 onSubmitted: (str) {

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -77,6 +77,10 @@ class CustomInputField extends StatelessWidget {
           children: <Widget>[
             Expanded(
               child: TextField(
+                autocorrect: false, // textfield autocorrect off
+                enableSuggestions: false,
+                keyboardType: TextInputType
+                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -83,7 +83,7 @@ class CustomInputField extends StatelessWidget {
                 enableSuggestions: false,
                 keyboardType: textInputType ??
                     TextInputType
-                        .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
+                        .text, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -699,6 +699,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     end: Offset.zero,
                   ).animate(_inputBoxController),
                   child: CustomInputField(
+                    textInputType: TextInputType.visiblePassword,
                     padding: EdgeInsets.only(right: 10),
                     width: 343.toWidth,
                     // height: 60.toHeight,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: at_follows_flutter
       ref: "fix/at_follows_flutter_example"
       resolved-ref: "4831bb7841df57486fd84c3228746510b95dc718"
-      url: "git@github.com:atsign-foundation/at_widgets.git"
+      url: "https://github.com/atsign-foundation/at_widgets.git"
     source: git
     version: "3.0.5"
   at_location_flutter:


### PR DESCRIPTION
- What I did
I disabled the search bar autocorrect and black space character input to solve the issue.

- How I did it
To disable autocorrect, Flutter's TextField Widget provides autocorrect option which I toggled to false, along with the enableSuggestions option. Also, this doesn't work if the device's keyboard's autocorrect is on. So I set the keyboardType as visiblePassword (TextInputType.visiblePassword). It prevents the autocorrect in both the cases.
To prevent blank space, I used the string replaceAll method and replaced white spaces to empty character in the onChanged function parameter of the textfield

- How to verify it
Type any user's atsign (for example barbaras). It previously autocorrected to Barbara's. Now it just displays barbaras, i.e. whatever we type. In case of blank spaces, the texfield won't accept the blank space in the input itself.

- Description for the changelog
Toggled Searchbar TextField autocorrect to false and set TextInputType to visiblePassword, for disabling autocorrect on the search bar.