### PR TITLE
Enhancement #161 (Make email addresses interactive)

### DIFF
--- a/lib/common_components/custom_card.dart
+++ b/lib/common_components/custom_card.dart
@@ -5,6 +5,7 @@ import 'package:at_wavi_app/utils/text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:at_wavi_app/services/size_config.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+import 'package:open_mail_app/open_mail_app.dart';
 
 class CustomCard extends StatelessWidget {
   final String? title, subtitle;
@@ -42,12 +43,35 @@ class CustomCard extends StatelessWidget {
             SizedBox(height: 6),
             subtitle != null
                 ? GestureDetector(
-                    onTap: () {
-                      if (!isUrl) {
-                        return;
+                    onTap: () async {
+                      // if (!isUrl) {
+                      //   return;
+                      // }
+                      // SetupRoutes.push(context, Routes.WEB_VIEW,
+                      //     arguments: {'title': title, 'url': subtitle});
+
+                      if (subtitle != null) {
+                        EmailContent emailContent = EmailContent(to: [
+                          subtitle!,
+                        ]);
+
+                        OpenMailAppResult result =
+                            await OpenMailApp.composeNewEmailInMailApp(
+                                nativePickerTitle:
+                                    'Select email app to compose',
+                                emailContent: emailContent);
+                        if (!result.didOpen && !result.canOpen) {
+                          // No Email App
+                        } else if (!result.didOpen && result.canOpen) {
+                          showDialog(
+                            context: context,
+                            builder: (_) => MailAppPickerDialog(
+                              mailApps: result.options,
+                              emailContent: emailContent,
+                            ),
+                          );
+                        }
                       }
-                      SetupRoutes.push(context, Routes.WEB_VIEW,
-                          arguments: {'title': title, 'url': subtitle});
                     },
                     child: HtmlWidget(
                       subtitle!,

--- a/lib/common_components/custom_card.dart
+++ b/lib/common_components/custom_card.dart
@@ -61,7 +61,14 @@ class CustomCard extends StatelessWidget {
                                     'Select email app to compose',
                                 emailContent: emailContent);
                         if (!result.didOpen && !result.canOpen) {
-                          // No Email App
+                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                            backgroundColor: Colors.red,
+                            content: Text(
+                              "No Email applications found",
+                              textAlign: TextAlign.center,
+                            ),
+                            duration: Duration(seconds: 1),
+                          ));
                         } else if (!result.didOpen && result.canOpen) {
                           showDialog(
                             context: context,

--- a/lib/common_components/custom_card.dart
+++ b/lib/common_components/custom_card.dart
@@ -44,39 +44,36 @@ class CustomCard extends StatelessWidget {
             subtitle != null
                 ? GestureDetector(
                     onTap: () async {
-                      // if (!isUrl) {
-                      //   return;
-                      // }
-                      // SetupRoutes.push(context, Routes.WEB_VIEW,
-                      //     arguments: {'title': title, 'url': subtitle});
-
+                      print(title);
                       if (subtitle != null) {
-                        EmailContent emailContent = EmailContent(to: [
-                          subtitle!,
-                        ]);
+                        if (title == "Email Address") {
+                          EmailContent emailContent = EmailContent(to: [
+                            subtitle!,
+                          ]);
 
-                        OpenMailAppResult result =
-                            await OpenMailApp.composeNewEmailInMailApp(
-                                nativePickerTitle:
-                                    'Select email app to compose',
-                                emailContent: emailContent);
-                        if (!result.didOpen && !result.canOpen) {
-                          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                            backgroundColor: Colors.red,
-                            content: Text(
-                              "No Email applications found",
-                              textAlign: TextAlign.center,
-                            ),
-                            duration: Duration(seconds: 1),
-                          ));
-                        } else if (!result.didOpen && result.canOpen) {
-                          showDialog(
-                            context: context,
-                            builder: (_) => MailAppPickerDialog(
-                              mailApps: result.options,
-                              emailContent: emailContent,
-                            ),
-                          );
+                          OpenMailAppResult result =
+                              await OpenMailApp.composeNewEmailInMailApp(
+                                  nativePickerTitle:
+                                      'Select email app to compose',
+                                  emailContent: emailContent);
+                          if (!result.didOpen && !result.canOpen) {
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                              backgroundColor: Colors.red,
+                              content: Text(
+                                "No Email applications found",
+                                textAlign: TextAlign.center,
+                              ),
+                              duration: Duration(seconds: 1),
+                            ));
+                          } else if (!result.didOpen && result.canOpen) {
+                            showDialog(
+                              context: context,
+                              builder: (_) => MailAppPickerDialog(
+                                mailApps: result.options,
+                                emailContent: emailContent,
+                              ),
+                            );
+                          }
                         }
                       }
                     },

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -19,6 +19,7 @@ class CustomInputField extends StatelessWidget {
   final bool expands;
   final int baseOffset;
   final EdgeInsets? padding;
+  final TextInputType? textInputType;
 
   var textController = TextEditingController();
 
@@ -45,6 +46,7 @@ class CustomInputField extends StatelessWidget {
     this.expands = false,
     this.baseOffset = 0,
     this.padding,
+    this.textInputType,
   });
 
   @override
@@ -79,8 +81,9 @@ class CustomInputField extends StatelessWidget {
               child: TextField(
                 autocorrect: false, // textfield autocorrect off
                 enableSuggestions: false,
-                keyboardType: TextInputType
-                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
+                keyboardType: textInputType ??
+                    TextInputType
+                        .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),
@@ -106,7 +109,7 @@ class CustomInputField extends StatelessWidget {
                 maxLines: expands ? null : maxLines,
                 expands: expands,
                 onChanged: (val) {
-                  if (value != null) value!(val);
+                  if (value != null) value!(val.replaceAll(' ', ''));
                 },
                 controller: textController,
                 onSubmitted: (str) {

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -77,6 +77,10 @@ class CustomInputField extends StatelessWidget {
           children: <Widget>[
             Expanded(
               child: TextField(
+                autocorrect: false, // textfield autocorrect off
+                enableSuggestions: false,
+                keyboardType: TextInputType
+                    .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),

--- a/lib/common_components/custom_input_field.dart
+++ b/lib/common_components/custom_input_field.dart
@@ -83,7 +83,7 @@ class CustomInputField extends StatelessWidget {
                 enableSuggestions: false,
                 keyboardType: textInputType ??
                     TextInputType
-                        .visiblePassword, // Tweak, if the device's keyboard's autocorrect is on
+                        .text, // Tweak, if the device's keyboard's autocorrect is on
                 readOnly: isReadOnly,
                 style: TextStyle(
                     fontSize: 15.toFont, color: textColor ?? Colors.white),

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -699,6 +699,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                     end: Offset.zero,
                   ).animate(_inputBoxController),
                   child: CustomInputField(
+                    textInputType: TextInputType.visiblePassword,
                     padding: EdgeInsets.only(right: 10),
                     width: 343.toWidth,
                     // height: 60.toHeight,

--- a/lib/services/common_functions.dart
+++ b/lib/services/common_functions.dart
@@ -293,6 +293,7 @@ class CommonFunctions {
           ],
         );
       }
+
       allFieldsWidget.add(widget);
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -839,6 +839,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  open_mail_app:
+    dependency: "direct main"
+    description:
+      name: open_mail_app
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.5"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       path: at_follows_flutter
       ref: "fix/at_follows_flutter_example"
       resolved-ref: "4831bb7841df57486fd84c3228746510b95dc718"
-      url: "git@github.com:atsign-foundation/at_widgets.git"
+      url: "https://github.com/atsign-foundation/at_widgets.git"
     source: git
     version: "3.0.5"
   at_location_flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,8 +52,9 @@ dependencies:
   at_follows_flutter: ^3.0.5
   at_location_flutter: ^3.1.2
   uni_links: ^0.5.1
-
+  
   flutter_dotenv: ^5.0.2  
+  open_mail_app:
 
 dependency_overrides:
   permission_handler: ^9.2.0


### PR DESCRIPTION
What I did
Made email address field interactive by opening the respective email app the user selects, after tapping on the email address field.

How I did it
I used a flutter package open_mail_app for the purpose. In the already provided GestureDetector widget for the email address field (custom_card.dart), in the onTap function, I used the prebuilt methods from the package to open the email app with the email address precomposed as soon as the user selects the app

How to verify it
For verification, just tap on the email address of the user, whose profile page you are on, currently. It opens an intent dialog box asking us to select the respective email app we want to use (get redirected to). Select Gmail app (for example). It will open the Gmail app and we can see the recipient's field already composed with the same mail address. If no email app is present in the device, a snackbar will be displayed in red.

Description for the changelog
Made the email address field interactive by providing mailing app options for the users to select and get redirected to the selected app for mailing.