### PR TITLE
Correction of TextFormField colors on CustomDialog

### DIFF
--- a/lib/desktop/services/theme/app_theme.dart
+++ b/lib/desktop/services/theme/app_theme.dart
@@ -138,11 +138,15 @@ class AppTheme {
 
   ThemeData toThemeData() {
     return ThemeData(
+      colorScheme: ThemeData().colorScheme.copyWith(
+          primary: ColorConstants.green,
+          secondary: ColorConstants.green,
+          brightness: brightness),
       brightness: brightness,
       primaryColor: primaryColor,
       backgroundColor: backgroundColor,
       scaffoldBackgroundColor: backgroundColor,
-      accentColor: accentColor,
+      // accentColor: accentColor,
       fontFamily: 'Inter',
       textTheme: textTheme,
     );

--- a/lib/utils/theme.dart
+++ b/lib/utils/theme.dart
@@ -9,6 +9,10 @@ class Themes {
     String? fontFamily,
   }) {
     return ThemeData(
+      colorScheme: ThemeData().colorScheme.copyWith(
+          primary: ColorConstants.green,
+          secondary: ColorConstants.green,
+          brightness: Brightness.light),
       brightness: Brightness.light,
       primaryColor: ColorConstants.black,
       primaryColorDark: getPrimaryColorDark(highlightColor, themeColor),
@@ -27,6 +31,10 @@ class Themes {
     String? fontFamily,
   }) {
     return ThemeData(
+      colorScheme: ThemeData().colorScheme.copyWith(
+          primary: ColorConstants.green,
+          secondary: ColorConstants.green,
+          brightness: Brightness.dark),
       brightness: Brightness.dark,
       canvasColor: Colors.black,
       primaryColor: ColorConstants.white,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Changed the TextFormField focus border color to the design color instead of the the default color of a TextFormField**

**- I added a colorScheme property to the ThemeData widget and set the primary and secondary properties to the Design color**

**- Tested it with my mobile device**

**- I added a colorScheme property to the ThemeData widget and set the primary and secondary properties to the Design color**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: I added a colorScheme property to the ThemeData widget and set the primary and secondary properties to the Design color
-->