### PR TITLE
Prevent showing of duplicate entries while searching an atsign

### DIFF
--- a/lib/desktop/screens/desktop_common/desktop_crop_image_page.dart
+++ b/lib/desktop/screens/desktop_common/desktop_crop_image_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:at_wavi_app/desktop/screens/desktop_common/crop_editor_helper.dart';

--- a/lib/desktop/screens/desktop_my_profile/desktop_search_atsign/desktop_search_atsign_model.dart
+++ b/lib/desktop/screens/desktop_my_profile/desktop_search_atsign/desktop_search_atsign_model.dart
@@ -7,10 +7,10 @@ import 'package:flutter/cupertino.dart';
 class DesktopSearchAtSignModel extends ChangeNotifier {
   final UserPreview userPreview;
 
-  List<User> _users = [];
+  List<SearchInstance> _searchInstance = [];
   LoadStatus _searchStatus = LoadStatus.initial;
 
-  List<User> get users => _users;
+  List<SearchInstance> get searchInstance => _searchInstance;
 
   LoadStatus get searchStatus => _searchStatus;
 
@@ -21,8 +21,8 @@ class DesktopSearchAtSignModel extends ChangeNotifier {
     notifyListeners();
     SearchInstance? _searchService =
         await SearchService().getAtsignDetails(keyword);
-    User? user = _searchService?.user;
-    _users = user == null ? [] : [user];
+    var _newSearchInstance = _searchService;
+    _searchInstance = _newSearchInstance == null ? [] : [_newSearchInstance];
     _searchStatus = LoadStatus.success;
     notifyListeners();
   }

--- a/lib/desktop/screens/desktop_my_profile/desktop_search_atsign/desktop_search_atsign_page.dart
+++ b/lib/desktop/screens/desktop_my_profile/desktop_search_atsign/desktop_search_atsign_page.dart
@@ -102,7 +102,7 @@ class _DesktopSearchAtSignPageState extends State<DesktopSearchAtSignPage> {
                       ),
                     );
                   } else if (model.searchStatus == LoadStatus.success) {
-                    if (model.users.isEmpty) {
+                    if (model.searchInstance.isEmpty) {
                       return Center(
                         child: Text(
                           Strings.desktop_empty,
@@ -112,17 +112,18 @@ class _DesktopSearchAtSignPageState extends State<DesktopSearchAtSignPage> {
                     } else {
                       return ListView.builder(
                         shrinkWrap: true,
-                        itemCount: model.users.length,
+                        itemCount: model.searchInstance.length,
                         itemBuilder: (context, index) {
                           return DesktopUserWidget(
-                            user: model.users[index],
+                            user: model.searchInstance[index].user,
                             // title: _displayingName(
                             //   firstname: model.users[index].firstname,
                             //   lastname: model.users[index].lastname,
                             // ),
                             // subTitle: '@${model.users[index].atsign}',
                             onPressed: () {
-                              _openUser(model.users[index]);
+                              _openUser(model.searchInstance[index].user,
+                                  model.searchInstance[index].fieldOrders);
                             },
                           );
                         },
@@ -141,8 +142,8 @@ class _DesktopSearchAtSignPageState extends State<DesktopSearchAtSignPage> {
     );
   }
 
-  void _openUser(User user) {
-    FieldOrderService().setPreviewOrder = {...FieldOrderService().fieldOrders};
+  void _openUser(User user, Map<String, List<String>> fieldOrders) {
+    FieldOrderService().setPreviewOrder = {...fieldOrders};
     Provider.of<UserPreview>(context, listen: false).setUser = user;
     Navigator.of(context).push(
       MaterialPageRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   validators: ^3.0.0
   latlong2: ^0.8.1
   image_cropper: ^1.5.0
-  extended_image: ^6.0.1
+  extended_image: ^6.2.1
   image: ^3.1.1
   showcaseview: ^1.1.1
   desktop_window: ^0.4.0


### PR DESCRIPTION
Contains a fix of [Wavi Desktop - Duplicate entries in the app](https://github.com/atsign-foundation/apps/issues/546#issue-1158897432) for wavi desktop.