### PR TITLE
fix: added atsign reset option when sync takes longer

### DIFF
--- a/lib/services/backend_service.dart
+++ b/lib/services/backend_service.dart
@@ -165,6 +165,8 @@ class BackendService {
       onErrorCallback: _onErrorCallback,
       primaryColor: (_themeProvider.highlightColor ?? ColorConstants.green),
       syncProgressCallback: _syncProgressCallback,
+      showRemoveAtsignOption: true,
+      onAtSignRemoved: onAtsignRemoved,
     );
     AtSyncUIService().sync(atSyncUIOverlay: AtSyncUIOverlay.dialog);
 
@@ -231,6 +233,14 @@ class BackendService {
           content: Text(syncProgress.message ?? 'Sync failed...'),
         ));
       }
+    }
+  }
+
+  onAtsignRemoved() {
+    if (Platform.isAndroid || Platform.isIOS) {
+      onboardNextAtsign();
+    } else {
+      onboardNextAtsign(isCheckDesktop: true);
     }
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added atsign reset option when sync takes longer

**- How I did it**
- passed  these parameters in sync init.
```
showRemoveAtsignOption: true,
onAtSignRemoved: onAtsignRemoved,
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->